### PR TITLE
Hot Fix which eliminates bulding error

### DIFF
--- a/minimal_rangeproc_impl/makefile_ccs_bootimage_gen
+++ b/minimal_rangeproc_impl/makefile_ccs_bootimage_gen
@@ -19,11 +19,11 @@ OBJCOPY=$(CG_TOOL_ROOT)/bin/tiarmobjcopy
 OUTFILE=$(PROFILE)/$(OUTNAME).out
 
 BOOTIMAGE_PATH=$(abspath ${PROFILE})
-BOOTIMAGE_BIN_NAME:=$(BOOTIMAGE_PATH)/hwa_fft1d.$(PROFILE).appimage
-BOOTIMAGE_BIN_TEMP:=hwa_fft1d.$(PROFILE)_temp.appimage
-BOOTIMAGE_RPRC_NAME_TMP:=hwa_fft1d.$(PROFILE)_rprc.bin
+BOOTIMAGE_BIN_NAME:=$(BOOTIMAGE_PATH)/minimal_rangeproc_impl.$(PROFILE).appimage
+BOOTIMAGE_BIN_TEMP:=minimal_rangeproc_impl.$(PROFILE)_temp.appimage
+BOOTIMAGE_RPRC_NAME_TMP:=minimal_rangeproc_impl.$(PROFILE)_rprc.bin
 AUTH_BOOTIMAGE_PATH=$(abspath .)
-AUTH_BOOTIMAGE_BIN_NAME:=$(BOOTIMAGE_PATH)/hwa_fft1d_auth.$(PROFILE).appimage
+AUTH_BOOTIMAGE_BIN_NAME:=$(BOOTIMAGE_PATH)/minimal_rangeproc_impl_auth.$(PROFILE).appimage
 BSS_RPRC_BIN:=$(MMW_DFP_PATH)/rfsfirmware/xWRL6432/mmwave_rfs_patch_rprc.bin
 
 #
@@ -44,7 +44,7 @@ INTEGRITY_GEN=$(MCU_PLUS_SDK_PATH)/tools/auth_tool/Integrity_generator$(EXE_EXT)
 SALT_PATH=$(MCU_PLUS_SDK_PATH)/tools/auth_tool/encsalt.txt
 INFO_PATH=$(MCU_PLUS_SDK_PATH)/tools/auth_tool/encinfo.txt
 SYMM_KEY_PATH=$(MCU_PLUS_SDK_PATH)/tools/auth_tool/encsymm.txt
-INTEGRITY_BIN=hwa_fft1d_integrity.bin
+INTEGRITY_BIN=minimal_rangeproc_impl_integrity.bin
 
 OUTRPRC_PATH=$(MCU_PLUS_SDK_PATH)/tools/boot/out2rprc/out2rprc.exe
 MULTI_CORE_IMAGE_GEN=$(MCU_PLUS_SDK_PATH)/tools/boot/multicoreImageGen/MulticoreImageGen$(EXE_EXT)
@@ -64,7 +64,7 @@ ifeq ($(CCS_IDE_MODE),cloud)
 else
 	@echo  Boot image: xwrL64xx:m4fss0-0:freertos:ti-arm-clang $(BOOTIMAGE_NAME) ...
 	@echo  Auth Boot image: xwrL64xx:m4fss0-0:freertos:ti-arm-clang $(AUTH_BOOTIMAGE_NAME) ...
-	(OUTRPRC_PATH) $(OUTFILE) $(BOOTIMAGE_RPRC_NAME_TMP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
+	$(OUTRPRC_PATH) $(OUTFILE) $(BOOTIMAGE_RPRC_NAME_TMP) >> $(BOOTIMAGE_TEMP_OUT_FILE)
 	$(INTEGRITY_GEN) $(SYMM_KEY_PATH) $(SALT_PATH) $(INFO_PATH) $(INTEGRITY_BIN) app $(BOOTIMAGE_RPRC_NAME_TMP) rfs $(BSS_RPRC_BIN)
 	$(MULTI_CORE_IMAGE_GEN) LE $(BOOT_MODE) $(BOOT_VECTOR_ADDRESS) $(SH_MEM_CONFIG) $(AUTH_BOOTIMAGE_BIN_NAME) $(INTEGRITY_FLAGS) $(INTEGRITY_BIN) $(APPS_FLAGS) $(BOOTIMAGE_RPRC_NAME_TMP) $(RFS_FLAGS) $(BSS_RPRC_BIN) >> $(AUTH_BOOTIMAGE_TEMP_OUT_FILE)
 	$(MULTI_CORE_IMAGE_GEN) LE $(BOOT_MODE) $(BOOT_VECTOR_ADDRESS) $(SH_MEM_CONFIG) $(BOOTIMAGE_BIN_NAME) $(APPS_FLAGS) $(BOOTIMAGE_RPRC_NAME_TMP) $(RFS_FLAGS) $(BSS_RPRC_BIN) >> $(BOOTIMAGE_TEMP_OUT_FILE)


### PR DESCRIPTION
Postprocessed `minimal_rangeproc_impl/makefile_ccs_bootimage_gen` script is changed to avoid binary image bulding issues. 